### PR TITLE
On the FreeNAS installation ISO image, /rescue

### DIFF
--- a/rescue/rescue/Makefile
+++ b/rescue/rescue/Makefile
@@ -192,6 +192,9 @@ CRUNCH_PROGS_usr.bin+= bzip2
 CRUNCH_ALIAS_bzip2= bunzip2 bzcat
 CRUNCH_LIBS+= -lbz2
 
+CRUNCH_PROGS_usr.bin+= less
+CRUNCH_ALIAS_less= more
+
 CRUNCH_PROGS_usr.bin+= xz
 CRUNCH_ALIAS_xz= unxz lzma unlzma xzcat lzcat
 CRUNCH_LIBS+= -llzma


### PR DESCRIPTION
is the directory which contains all the executables which run
from the shell.  /usr/bin , /usr/sbin, /sbin , /bin are all symlinks
to /rescue.  To add a new executable to the ISO image, you
need to add it to /rescue.

Add /rescue/less to the ISO, and add /rescue/more as a link to /rescue/less.
