### PR TITLE
Remove dialog from rescue Makefile.

### DIFF
--- a/rescue/rescue/Makefile
+++ b/rescue/rescue/Makefile
@@ -211,10 +211,6 @@ CRUNCH_ALIAS_vi= ex
 CRUNCH_PROGS_usr.bin+= id
 CRUNCH_ALIAS_id= groups whoami
 
-CRUNCH_PROGS_usr.bin+= dialog
-CRUNCH_SRCDIR_dialog= ${.CURDIR}/../../gnu/usr.bin/dialog
-CRUNCH_LIBS+= -ldialog -lm -lncursesw -ltermlibw -ltinfow
-
 CRUNCH_SRCDIR_sort= ${.CURDIR}/../../gnu/usr.bin/sort
 
 ##################################################################


### PR DESCRIPTION
dialog introduces unwanted dependencies in rescue.
If we want to add a binary to the installation ISO,
we should explicitly add it to the scripts which create
the install ISO, and not modify src/rescue/rescue/Makefile.

In FreeNAS, we cleaned up the create_iso.sh script in these changesets:
d29cbfcc8e9bed8510b59dd86e3e93f3c0e00ea2
db5e03a1451c6e3cac5bb3765897feda6ab940be

so that the install ISO takes dialog from /usr/bin/dialog and _not_ /rescue/dialog.
