### PR TITLE
Improve new_only handling.

### DIFF
--- a/etc/defaults/periodic.conf
+++ b/etc/defaults/periodic.conf
@@ -170,7 +170,7 @@ daily_status_security_inline="NO"			# Run inline ?
 daily_status_security_output="root"			# user or /file
 daily_status_security_noamd="NO"			# Don't check amd mounts
 daily_status_security_logdir="/var/log"			# Directory for logs
-daily_status_security_diff_flags="-b -u"		# flags for diff output
+daily_status_security_diff_flags="-b"   		# flags for diff output
 
 # 100.chksetuid
 daily_status_security_chksetuid_enable="YES"

--- a/etc/periodic/security/security.functions
+++ b/etc/periodic/security/security.functions
@@ -63,12 +63,13 @@ check_diff() {
     cp ${tmpf} ${LOG}/${label}.today || rc=3
   fi
 
-  if ! cmp -s ${LOG}/${label}.today ${tmpf} >/dev/null; then
+  diff=$(diff ${daily_status_security_diff_flags} ${LOG}/${label}.today \
+    ${tmpf} | eval "${filter}")
+  if [ -n "${diff}" ]; then
     [ $rc -lt 1 ] && rc=1
     echo ""
     echo "${msg}"
-    diff ${daily_status_security_diff_flags} ${LOG}/${label}.today \
-	${tmpf} | eval "${filter}"
+    echo "${diff}"
     mv ${LOG}/${label}.today ${LOG}/${label}.yesterday || rc=3
     mv ${tmpf} ${LOG}/${label}.today || rc=3
   fi


### PR DESCRIPTION
When called with new_only check_diff() would return with exit status 1 even
when there was no new line but some lines disappeared (for example, messages
expiring from the dmesg buffer:
http://forums.freenas.org/threads/security-run-output-possible-error.15660/).
It still only works properly for normal diff, so the default diff option was
modified. I was tempted to change the new_only filter to "egrep '^(>|+[^+])'"
That would filter out the unified diff +++ header, but would also remove
possible new lines starting with a +.
Needed for: https://bugs.freenas.org/issues/3361
