### PR TITLE
Allow sysctl kern.vm_guest to return bhyve when running under bhyve.

### DIFF
--- a/sys/kern/subr_param.c
+++ b/sys/kern/subr_param.c
@@ -159,6 +159,7 @@ static const char *const vm_guest_sysctl_names[] = {
 	"xen",
 	"hv",
 	"vmware",
+	"bhyve",
 	NULL
 };
 CTASSERT(nitems(vm_guest_sysctl_names) - 1 == VM_LAST);

--- a/sys/sys/systm.h
+++ b/sys/sys/systm.h
@@ -74,7 +74,7 @@ extern int vm_guest;		/* Running as virtual machine guest? */
  * Keep in sync with vm_guest_sysctl_names[].
  */
 enum VM_GUEST { VM_GUEST_NO = 0, VM_GUEST_VM, VM_GUEST_XEN, VM_GUEST_HV,
-		VM_GUEST_VMWARE, VM_LAST };
+		VM_GUEST_VMWARE, VM_GUEST_BHYVE, VM_LAST };
 
 #if defined(WITNESS) || defined(INVARIANTS)
 void	kassert_panic(const char *fmt, ...)  __printflike(1, 2);

--- a/sys/x86/x86/identcpu.c
+++ b/sys/x86/x86/identcpu.c
@@ -1257,6 +1257,8 @@ identify_hypervisor(void)
 				vm_guest = VM_GUEST_VMWARE;
 			else if (strcmp(hv_vendor, "Microsoft Hv") == 0)
 				vm_guest = VM_GUEST_HV;
+			else if (strcmp(hv_vendor, "bhyve bhyve ") == 0)
+				vm_guest = VM_GUEST_BHYVE;
 		}
 		return;
 	}


### PR DESCRIPTION
Ticket: #17046

Also, this should be merged into whatever branch FN9 is using.