### PR TITLE
add SIOCGIFORIGNAME: get "original" interface name

### DIFF
--- a/sys/net/if.c
+++ b/sys/net/if.c
@@ -2506,6 +2506,19 @@ ifhwioctl(u_long cmd, struct ifnet *ifp, caddr_t data, struct thread *td)
 		break;
 #endif
 
+	case SIOCGIFORIGNAME:
+		/*
+		 * Getting the interface name seems like a strange
+		 * thing to do: you pass in "xyz12" and get its name,
+		 * won't that be "xyz12"?  Well, no ... at least,
+		 * not if you have used SIOCSIFNAME.  This gets the
+		 * original name, i.e., the driver name and driver
+		 * unit.
+		 */
+		snprintf(ifr->ifr_name, sizeof(ifr->ifr_name), "%s%d",
+		    ifp->if_dname, ifp->if_dunit);
+		break;
+
 	case SIOCSIFMETRIC:
 		error = priv_check(td, PRIV_NET_SETIFMETRIC);
 		if (error)

--- a/sys/sys/sockio.h
+++ b/sys/sys/sockio.h
@@ -81,6 +81,7 @@
 #define	SIOCSIFDESCR	 _IOW('i', 41, struct ifreq)	/* set ifnet descr */ 
 #define	SIOCGIFDESCR	_IOWR('i', 42, struct ifreq)	/* get ifnet descr */ 
 #define	SIOCAIFADDR	 _IOW('i', 43, struct ifaliasreq)/* add/chg IF alias */
+#define	SIOCGIFORIGNAME	_IOWR('i', 44, struct ifreq)	/* get IF origname */
 
 #define	SIOCADDMULTI	 _IOW('i', 49, struct ifreq)	/* add m'cast addr */
 #define	SIOCDELMULTI	 _IOW('i', 50, struct ifreq)	/* del m'cast addr */


### PR DESCRIPTION
This lets you find the original name of a renamed interface.
(The primary use for this is FreeNAS middleware specific.)

Ticket: #19229

---
@jceel Note, this has not actually been tested yet (but it builds OK) - needs to be tested in conjunction with the py-netif change