### PR TITLE
Modify /etc/rc.d/nfsd so it doesn't force a startup of nfsuserd for N…

### DIFF
--- a/etc/rc.d/nfsd
+++ b/etc/rc.d/nfsd
@@ -33,8 +33,7 @@ nfsd_precmd()
 		sysctl vfs.nfsd.nfs_privport=0 > /dev/null
 	fi
 
-	if checkyesno nfsv4_server_enable || \
-	    checkyesno nfs_server_managegids; then
+	if checkyesno nfs_server_managegids; then
 		force_depend nfsuserd || err 1 "Cannot run nfsuserd"
 	fi
 


### PR DESCRIPTION
…FSv4.

Given that RFC7530 allows uid/gids to be placed in owner/owner_group
strings directly, many NFSv4 environments don't need the nfsuserd.
This small patch modified /etc/rc.d/nfsd so that it does not force
startup of the nfsuserd daemon unless nfs_server_managegids is enabled.
This implies that nfsuserd_enable="YES" must be added to /etc/rc.conf
for NFSv4 server environments that use Kerberos mounts or clients that
do not support the uid/gid in string capability.
Since this could be considered a POLA violation, it will not be MFC'd.

Discussed on:	freebsd-current


git-svn-id: svn+ssh://svn.freebsd.org/base/head@321665 ccf9f872-aa2e-dd11-9fc8-001c23d0bc1f