### PR TITLE
Bumping the number of possible threads for the nfsd process to 4096.

### DIFF
--- a/usr.sbin/nfsd/nfsd.c
+++ b/usr.sbin/nfsd/nfsd.c
@@ -80,7 +80,7 @@ static int	debug = 0;
 
 #define	NFSD_STABLERESTART	"/var/db/nfs-stablerestart"
 #define	NFSD_STABLEBACKUP	"/var/db/nfs-stablerestart.bak"
-#define	MAXNFSDCNT	256
+#define	MAXNFSDCNT	4096
 #define	DEFNFSDCNT	 4
 #define	NFS_VER2	 2
 #define NFS_VER3	 3


### PR DESCRIPTION
This is to only define the upper limit of the amount of threads not necessarily change the default number of threads.

Hey Mav, we have a customer that has ~1400 simultaneous nfs clients connecting to the TrueNAS device. I'm changing the upper limit to 4096. This is controllable via the vfs.nfsd.maxthreads sysctl value so it would not be changing default behavior out of the box. The customer is adamant that they should be able to change this because they have had to change this on past appliances (Oracle, NetAPP).