### PR TITLE
Partially revert increase of negotiation polling interval.

### DIFF
--- a/sys/dev/ntb/ntb_hw/ntb_hw_intel.c
+++ b/sys/dev/ntb/ntb_hw/ntb_hw_intel.c
@@ -2689,7 +2689,7 @@ reschedule:
 	ntb->lnk_sta = pci_read_config(ntb->device, ntb->reg->lnk_sta, 2);
 	if (_xeon_link_is_up(ntb)) {
 		callout_reset(&ntb->peer_msix_work,
-		    hz * (ntb->peer_msix_good ? 2 : 1) / 10,
+		    hz * (ntb->peer_msix_good ? 20 : 1) / 100,
 		    intel_ntb_exchange_msix, ntb);
 	} else
 		intel_ntb_spad_clear(ntb->device);


### PR DESCRIPTION
This should reduce chance of collision when upgrading from old version
to new, when due to race in the protocol it is possible for one side to
decide that link is up, while another side remains in negotiation.

Ticket:	#27643