### PR TITLE
MFC: r323978

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ throttle(['FreeNAS']) {
         } catch (exc) {
           echo 'Saving failed artifacts...'
           archiveArtifacts artifacts: 'artifacts/**', fingerprint: true
-          throw
+          throw exc
         }
       }
       stage('artifact') {

--- a/sys/fs/nfsserver/nfs_nfsdserv.c
+++ b/sys/fs/nfsserver/nfs_nfsdserv.c
@@ -921,7 +921,7 @@ nfsrvd_write(struct nfsrv_descript *nd, __unused int isdgram,
 		    nd->nd_md, nd->nd_dpos, nd->nd_cred, p);
 		error = nfsm_advance(nd, NFSM_RNDUP(retlen), -1);
 		if (error)
-			panic("nfsrv_write mbuf");
+			goto nfsmout;
 	}
 	if (nd->nd_flag & ND_NFSV4)
 		aftat_ret = 0;


### PR DESCRIPTION
Don't panic!

Change a panic to an error return.

There was a panic() in the NFS server's write operation that didn't
need to be a panic() and could just be an error return.
This patch makes that change.
Found by code inspection during development of the pNFS service.

(cherry picked from commit 4db271097f8fa53efde07760f5f837eec5c4c1ae)