### PR TITLE
[master]  fix(ha): Create sysctl to set DSCP on Carp

### DIFF
--- a/share/man/man4/carp.4
+++ b/share/man/man4/carp.4
@@ -102,6 +102,12 @@ Allow virtual hosts to preempt each other.
 When enabled, a vhid in a backup state would preempt a master that
 is announcing itself with a lower advskew.
 Disabled by default.
+.It Va net.inet.carp.dscp
+Set DSCP value in carp packet
+When enabled, it sets DSCP value CS7 for network control in outgoing
+carp packets instead of TOS. TOS values were deprecated and replaced
+by DSCP in 1998.
+Disabled by default.
 .It Va net.inet.carp.log
 Determines what events relating to
 .Nm

--- a/share/man/man4/carp.4
+++ b/share/man/man4/carp.4
@@ -108,7 +108,7 @@ When enabled, set Class of Service to CS7 (network control) in outgoing
 carp packets.
 When disabled, Class of Service is set to TOS LOW_DELAY.
 TOS values were deprecated and replaced by DSCP in 1998.
-Disabled by default.
+Enabled by default.
 .It Va net.inet.carp.log
 Determines what events relating to
 .Nm

--- a/share/man/man4/carp.4
+++ b/share/man/man4/carp.4
@@ -26,7 +26,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd February 21, 2013
+.Dd February 23, 2018
 .Dt CARP 4
 .Os
 .Sh NAME
@@ -104,9 +104,10 @@ is announcing itself with a lower advskew.
 Disabled by default.
 .It Va net.inet.carp.dscp
 Set DSCP value in carp packet
-When enabled, it sets DSCP value CS7 for network control in outgoing
-carp packets instead of TOS. TOS values were deprecated and replaced
-by DSCP in 1998.
+When enabled, set Class of Service to CS7 (network control) in outgoing
+carp packets.
+When disabled, Class of Service is set to TOS LOW_DELAY.
+TOS values were deprecated and replaced by DSCP in 1998.
 Disabled by default.
 .It Va net.inet.carp.log
 Determines what events relating to

--- a/sys/netinet/ip6.h
+++ b/sys/netinet/ip6.h
@@ -102,6 +102,7 @@ struct ip6_hdr {
 #define IPV6_FLOWLABEL_MASK	0xffff0f00	/* flow label (20 bits) */
 #endif /* LITTLE_ENDIAN */
 #endif
+#define IPV6_FLOWLABEL_LEN	20
 #if 1
 /* ECN bits proposed by Sally Floyd */
 #define IP6TOS_CE		0x01	/* congestion experienced */

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -939,8 +939,7 @@ carp_send_ad_locked(struct carp_softc *sc)
 		ip->ip_hl = sizeof(*ip) >> 2;
 		if (V_carp_dscp) {
 			ip->ip_tos = IPTOS_DSCP_CS7;
-		}
-		else {
+		} else {
 			ip->ip_tos = IPTOS_LOWDELAY;
 		}	
 		ip->ip_len = htons(len);
@@ -995,8 +994,7 @@ carp_send_ad_locked(struct carp_softc *sc)
                 if (V_carp_dscp) {
 			/* Traffic class isn't defined in ip6 struct instead  
 			 * it gets offset into flowid field */
-			uint8_t LEN_FLOW_LABEL = 20;
-                	ip6->ip6_flow |= IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
+                	ip6->ip6_flow |= htonl(IPTOS_DSCP_CS7 << IPV6_FLOWLABEL_LEN);
 		}
 		ip6->ip6_hlim = CARP_DFLTTL;
 		ip6->ip6_nxt = IPPROTO_CARP;

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -996,7 +996,7 @@ carp_send_ad_locked(struct carp_softc *sc)
 			uint8_t LEN_FLOW_LABEL = 20;
 			/* Traffic class isn't defined in ip6 struct instead  
 			 * it gets offset into flowid field */
-			uint8_t ip_tos = IPTOS_LOWDELAY << LEN_FLOW_LABEL;
+			uint8_t ip_tos = IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
                 	ip6->ip6_flow |= ip_tos;
 		}
 		ip6->ip6_hlim = CARP_DFLTTL;

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -191,7 +191,7 @@ static VNET_DEFINE(int, carp_allow) = 1;
 #define	V_carp_allow	VNET(carp_allow)
 
 /* Set DSCP in outgoing CARP packets. */
-static VNET_DEFINE(int, carp_dscp) = 0;
+static VNET_DEFINE(int, carp_dscp) = 1;
 #define	V_carp_dscp	VNET(carp_dscp)
 
 /* Preempt slower nodes. */
@@ -922,16 +922,11 @@ carp_send_ad_locked(struct carp_softc *sc)
 #ifdef INET
 	if (sc->sc_naddrs) {
 		struct ip *ip;
-		uint8_t ip_tos = IPTOS_DSCP_CS7;
-		
-		
+
 		m = m_gethdr(M_NOWAIT, MT_DATA);
 		if (m == NULL) {
 			CARPSTATS_INC(carps_onomem);
 			goto resched;
-		}
-                if (!V_carp_dscp) {
-			ip_tos = IPTOS_LOWDELAY;
 		}
 		len = sizeof(*ip) + sizeof(ch);
 		m->m_pkthdr.len = len;
@@ -942,7 +937,12 @@ carp_send_ad_locked(struct carp_softc *sc)
 		ip = mtod(m, struct ip *);
 		ip->ip_v = IPVERSION;
 		ip->ip_hl = sizeof(*ip) >> 2;
-		ip->ip_tos = ip_tos;
+		if (V_carp_dscp) {
+			ip->ip_tos = IPTOS_DSCP_CS7;
+		}
+		else {
+			ip->ip_tos = IPTOS_LOWDELAY;
+		}	
 		ip->ip_len = htons(len);
 		ip->ip_off = htons(IP_DF);
 		ip->ip_ttl = CARP_DFLTTL;
@@ -993,11 +993,10 @@ carp_send_ad_locked(struct carp_softc *sc)
 		bzero(ip6, sizeof(*ip6));
 		ip6->ip6_vfc |= IPV6_VERSION;
                 if (V_carp_dscp) {
-			uint8_t LEN_FLOW_LABEL = 20;
 			/* Traffic class isn't defined in ip6 struct instead  
 			 * it gets offset into flowid field */
-			uint32_t ip_tos = IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
-                	ip6->ip6_flow |= ip_tos;
+			uint8_t LEN_FLOW_LABEL = 20;
+                	ip6->ip6_flow |= IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
 		}
 		ip6->ip6_hlim = CARP_DFLTTL;
 		ip6->ip6_nxt = IPPROTO_CARP;

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -996,7 +996,7 @@ carp_send_ad_locked(struct carp_softc *sc)
 			uint8_t LEN_FLOW_LABEL = 20;
 			/* Traffic class isn't defined in ip6 struct instead  
 			 * it gets offset into flowid field */
-			uint8_t ip_tos = IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
+			uint32_t ip_tos = IPTOS_DSCP_CS7 << LEN_FLOW_LABEL;
                 	ip6->ip6_flow |= ip_tos;
 		}
 		ip6->ip6_hlim = CARP_DFLTTL;

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -190,6 +190,10 @@ static int proto_reg[] = {-1, -1};
 static VNET_DEFINE(int, carp_allow) = 1;
 #define	V_carp_allow	VNET(carp_allow)
 
+/* Set DSCP in outgoing CARP packets. */
+static VNET_DEFINE(int, carp_dscp) = 0;
+#define	V_carp_dscp	VNET(carp_dscp)
+
 /* Preempt slower nodes. */
 static VNET_DEFINE(int, carp_preempt) = 0;
 #define	V_carp_preempt	VNET(carp_preempt)
@@ -215,6 +219,8 @@ static int carp_demote_adj_sysctl(SYSCTL_HANDLER_ARGS);
 SYSCTL_NODE(_net_inet, IPPROTO_CARP,	carp,	CTLFLAG_RW, 0,	"CARP");
 SYSCTL_INT(_net_inet_carp, OID_AUTO, allow, CTLFLAG_VNET | CTLFLAG_RW,
     &VNET_NAME(carp_allow), 0, "Accept incoming CARP packets");
+SYSCTL_INT(_net_inet_carp, OID_AUTO, dscp, CTLFLAG_VNET | CTLFLAG_RW,
+    &VNET_NAME(carp_dscp), 0, "Use DSCP CS7 for carp packets");
 SYSCTL_INT(_net_inet_carp, OID_AUTO, preempt, CTLFLAG_VNET | CTLFLAG_RW,
     &VNET_NAME(carp_preempt), 0, "High-priority backup preemption mode");
 SYSCTL_INT(_net_inet_carp, OID_AUTO, log, CTLFLAG_VNET | CTLFLAG_RW,
@@ -916,11 +922,16 @@ carp_send_ad_locked(struct carp_softc *sc)
 #ifdef INET
 	if (sc->sc_naddrs) {
 		struct ip *ip;
-
+		uint8_t ip_tos = IPTOS_DSCP_CS7;
+		
+		
 		m = m_gethdr(M_NOWAIT, MT_DATA);
 		if (m == NULL) {
 			CARPSTATS_INC(carps_onomem);
 			goto resched;
+		}
+                if (!V_carp_dscp) {
+			ip_tos = IPTOS_LOWDELAY;
 		}
 		len = sizeof(*ip) + sizeof(ch);
 		m->m_pkthdr.len = len;
@@ -931,7 +942,7 @@ carp_send_ad_locked(struct carp_softc *sc)
 		ip = mtod(m, struct ip *);
 		ip->ip_v = IPVERSION;
 		ip->ip_hl = sizeof(*ip) >> 2;
-		ip->ip_tos = IPTOS_LOWDELAY;
+		ip->ip_tos = ip_tos;
 		ip->ip_len = htons(len);
 		ip->ip_off = htons(IP_DF);
 		ip->ip_ttl = CARP_DFLTTL;
@@ -981,6 +992,13 @@ carp_send_ad_locked(struct carp_softc *sc)
 		ip6 = mtod(m, struct ip6_hdr *);
 		bzero(ip6, sizeof(*ip6));
 		ip6->ip6_vfc |= IPV6_VERSION;
+                if (!V_carp_dscp) {
+			uint8_t LEN_FLOW_LABEL = 20;
+			/* Traffic class isn't defined in ip6 struct instead  
+			 * it gets offset into flowid field */
+			uint8_t ip_tos = IPTOS_LOWDELAY << LEN_FLOW_LABEL;
+                	ip6->ip6_flow |= ip_tos;
+		}
 		ip6->ip6_hlim = CARP_DFLTTL;
 		ip6->ip6_nxt = IPPROTO_CARP;
 

--- a/sys/netinet/ip_carp.c
+++ b/sys/netinet/ip_carp.c
@@ -992,7 +992,7 @@ carp_send_ad_locked(struct carp_softc *sc)
 		ip6 = mtod(m, struct ip6_hdr *);
 		bzero(ip6, sizeof(*ip6));
 		ip6->ip6_vfc |= IPV6_VERSION;
-                if (!V_carp_dscp) {
+                if (V_carp_dscp) {
 			uint8_t LEN_FLOW_LABEL = 20;
 			/* Traffic class isn't defined in ip6 struct instead  
 			 * it gets offset into flowid field */


### PR DESCRIPTION
fix(ha): Create sysctl to set DSCP CS7(network control traffic) on
    carp traffic. This will allow switches to use qos to avoid dropping
    packets. By default sysctl is set to false not changing behavior
    Ticket: 28395
