### PR TITLE
Split path in currdev variable by the last colon, not the second.

### DIFF
--- a/stand/zfs/zfs.c
+++ b/stand/zfs/zfs.c
@@ -660,7 +660,7 @@ zfs_parsedev(struct zfs_devdesc *dev, const char *devspec, const char **path)
 	if (*np != ':')
 		return (EINVAL);
 	np++;
-	end = strchr(np, ':');
+	end = strrchr(np, ':');
 	if (end == NULL)
 		return (EINVAL);
 	sep = strchr(np, '/');


### PR DESCRIPTION
If boot environment name includes colon in its name (like time),
then this code will interpret it as separator and won't be able to
find a dataset by the incomplete name to load the kernel from.
This change is based on assumption that path is almost never really
used there, and even if used, there are rarely colons in it.

Ticket:	#36118