### PR TITLE
- Improve bhyve exit(3) error code.

### DIFF
--- a/usr.sbin/bhyve/bhyve.8
+++ b/usr.sbin/bhyve/bhyve.8
@@ -24,7 +24,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd July 28, 2017
+.Dd Jul 11, 2018
 .Dt BHYVE 8
 .Os
 .Sh NAME
@@ -431,6 +431,8 @@ powered off
 halted
 .It 3
 triple fault
+.It 4
+exited due to an error
 .El
 .Sh EXAMPLES
 If not using a boot ROM, the guest operating system must have been loaded with

--- a/usr.sbin/bhyve/dbgport.c
+++ b/usr.sbin/bhyve/dbgport.c
@@ -139,8 +139,8 @@ init_dbgport(int sport)
 	conn_fd = -1;
 
 	if ((listen_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		perror("socket");
-		exit(1);
+		perror("cannot create socket");
+		exit(4);
 	}
 
 	sin.sin_len = sizeof(sin);
@@ -151,18 +151,18 @@ init_dbgport(int sport)
 	reuse = 1;
 	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse,
 	    sizeof(reuse)) < 0) {
-		perror("setsockopt");
-		exit(1);
+		perror("cannot set socket options");
+		exit(4);
 	}
 
 	if (bind(listen_fd, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-		perror("bind");
-		exit(1);
+		perror("cannot bind socket");
+		exit(4);
 	}
 
 	if (listen(listen_fd, 1) < 0) {
-		perror("listen");
-		exit(1);
+		perror("cannot listen socket");
+		exit(4);
 	}
 
 #ifndef WITHOUT_CAPSICUM

--- a/usr.sbin/bhyve/fwctl.c
+++ b/usr.sbin/bhyve/fwctl.c
@@ -373,7 +373,7 @@ fwctl_request(uint32_t value)
 		/* Verify size */
 		if (value < 12) {
 			printf("msg size error");
-			exit(1);
+			exit(4);
 		}
 		rinfo.req_size = value;
 		rinfo.req_count = 1;

--- a/usr.sbin/bhyve/mevent_test.c
+++ b/usr.sbin/bhyve/mevent_test.c
@@ -143,7 +143,7 @@ echoer(void *param)
 	mev = mevent_add(fd, EVF_READ, echoer_callback, &sync);
 	if (mev == NULL) {
 		printf("Could not allocate echoer event\n");
-		exit(1);
+		exit(4);
 	}
 
 	while (!pthread_cond_wait(&sync.e_cond, &sync.e_mt)) {
@@ -199,25 +199,25 @@ acceptor(void *param)
 	int s;
 	static int first;
 
-        if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-                perror("socket");
-                exit(1);
-        }
+	if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("cannot create socket");
+		exit(4);
+	}
 
-        sin.sin_len = sizeof(sin);
-        sin.sin_family = AF_INET;
-        sin.sin_addr.s_addr = htonl(INADDR_ANY);
-        sin.sin_port = htons(TEST_PORT);
+	sin.sin_len = sizeof(sin);
+	sin.sin_family = AF_INET;
+	sin.sin_addr.s_addr = htonl(INADDR_ANY);
+	sin.sin_port = htons(TEST_PORT);
 
-        if (bind(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
-                perror("bind");
-                exit(1);
-        }
+	if (bind(s, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+		perror("cannot bind socket");
+		exit(4);
+	}
 
-        if (listen(s, 1) < 0) {
-                perror("listen");
-                exit(1);
-        }
+	if (listen(s, 1) < 0) {
+		perror("cannot listen socket");
+		exit(4);
+	}
 
 	(void) mevent_add(s, EVF_READ, acceptor_callback, NULL);
 

--- a/usr.sbin/bhyve/pci_e82545.c
+++ b/usr.sbin/bhyve/pci_e82545.c
@@ -2222,7 +2222,7 @@ e82545_open_tap(struct e82545_softc *sc, char *opts)
 	sc->esc_tapfd = open(tbuf, O_RDWR);
 	if (sc->esc_tapfd == -1) {
 		DPRINTF("unable to open tap device %s\n", opts);
-		exit(1);
+		exit(4);
 	}
 
 	/*


### PR DESCRIPTION
The bhyve(8) exit status indicates how the VM was terminated:

0	rebooted
1	powered off
2	halted
3	triple fault

The problem is when we have wrappers around bhyve that parses the exit
error code and gets an exit(1) for an error but interprets it as "powered off".
So to mitigate this issue and makes it less error prone for third part
applications, I have added a new exit code 4 that is "exited due to an error".

For now the bhyve(8) exit status are:
0	rebooted
1	powered off
2	halted
3	triple fault
4	exited due to an error

Reviewed by:	@jhb
MFC after:	2 weeks.
Sponsored by:	iXsystems Inc.
Differential Revision:	https://reviews.freebsd.org/D16161

Cherry-pick: 784d607328d1205ced136be9f87c76ee51bcac5e