### PR TITLE
- Remove double free.

### DIFF
--- a/usr.sbin/bhyve/vncserver.c
+++ b/usr.sbin/bhyve/vncserver.c
@@ -451,6 +451,5 @@ vncserver_init(char *hostname, int port, int wait, char *password, int webserver
 		pthread_mutex_unlock(&sc->vs_mtx);
 	}
 
-	free(sc);
 	return (0);
 }


### PR DESCRIPTION
On libhyve-remote function vnc_init_server() we free already the struct server_softc *sc,
we don't need free it on bhyve/vncserver.c. This was probably the
root cause of a SIGBUS.

Ticket: #37842, #37786 and possible #34747