### PR TITLE
Vncserver fix

### DIFF
--- a/usr.sbin/bhyve/vncserver.c
+++ b/usr.sbin/bhyve/vncserver.c
@@ -180,8 +180,6 @@ vncserver_send_screen(struct vncserver_softc *sc, int all)
 
 	console_refresh();
 
-	pthread_mutex_unlock(&sc->vs_mtx);
-
 	pthread_mutex_lock(&sc->vs_mtx);
 	if (sc->vs_sending) {
 		pthread_mutex_unlock(&sc->vs_mtx);
@@ -438,10 +436,11 @@ vncserver_init(char *hostname, int port, int wait, char *password, int webserver
         }
         */
 
+	vnc_init_server(sc, hostname);
+
 	pthread_create(&sc->vs_tid, NULL, vncserver_thr, sc);
 	pthread_set_name_np(sc->vs_tid, "vncserver");
 
-	vnc_init_server(sc, hostname);
 	vnc_event_loop(-1, true);
 
 	if (wait) {

--- a/usr.sbin/bhyve/vncserver.c
+++ b/usr.sbin/bhyve/vncserver.c
@@ -451,6 +451,5 @@ vncserver_init(char *hostname, int port, int wait, char *password, int webserver
 		pthread_mutex_unlock(&sc->vs_mtx);
 	}
 
-	free(sc);
 	return (0);
 }


### PR DESCRIPTION
- Remove unnecessary pthread_mutex_unlock().
- Call vnc_init_server prior to create a thread with vncserver_thr.

Suggested by: mav@