### PR TITLE
Create separate taskqueue to call zfs_unlinked_drain().

### DIFF
--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_dir.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_dir.c
@@ -388,6 +388,10 @@ zfs_purgedir(znode_t *dzp)
 	return (skipped);
 }
 
+#if defined(__FreeBSD__)
+extern taskq_t *zfsvfs_taskq;
+#endif
+
 void
 zfs_rmnode(znode_t *zp)
 {
@@ -486,15 +490,17 @@ zfs_rmnode(znode_t *zp)
 
 	dmu_tx_commit(tx);
 
+#if defined(__FreeBSD__)
 	if (xattr_obj) {
 		/*
 		 * We're using the FreeBSD taskqueue API here instead of
 		 * the Solaris taskq API since the FreeBSD API allows for a
 		 * task to be enqueued multiple times but executed once.
 		 */
-		taskqueue_enqueue(system_taskq->tq_queue,
+		taskqueue_enqueue(zfsvfs_taskq->tq_queue,
 		    &zfsvfs->z_unlinked_drain_task);
 	}
+#endif
 }
 
 static uint64_t


### PR DESCRIPTION
r334810 introduced zfs_unlinked_drain() dispatch to taskqueue on every
deletion of a file with extended attributes.  Using system_taskq for that
with its multiple threads in case of multiple files deletion caused all
available CPU threads to uselessly spin on busy locks, completely blocking
the system.

Use of single dedicated taskqueue is the only easy solution I've found,
while in would be great if we could specify that some task should be
executed only once at a time, but never in parallel, while many tasks
could use different threads same time.

Sponsored by:	iXsystems, Inc.
Ticket:	#41910

(cherry picked from commit c1c7ce6e54560a6cfd7340d6bd6d85a5dc47798e)