### PR TITLE
Update the free page count when blacklisting pages.

### DIFF
--- a/sys/vm/vm_page.c
+++ b/sys/vm/vm_page.c
@@ -304,6 +304,8 @@ vm_page_blacklist_add(vm_paddr_t pa, bool verbose)
 
 	mtx_lock(&vm_page_queue_free_mtx);
 	ret = vm_phys_unfree_page(m);
+	if (ret != 0)
+		vm_phys_freecnt_adj(m, -1);
 	mtx_unlock(&vm_page_queue_free_mtx);
 	if (ret) {
 		TAILQ_INSERT_TAIL(&blacklist_head, m, listq);


### PR DESCRIPTION
Otherwise the free page count will not accurately reflect the physical
page allocator's state. On 11 this can trigger panics in
vm_page_alloc() since the allocator state and free page count are
updated atomically and we expect them to stay in sync. On 12 the
bug would manifest as threads looping in vm_page_alloc().

PR:		231296
Reported by:	mav, wollman, Rainer Duffner, Josh Gitlin
Reviewed by:	alc, kib, mav
MFC after:	3 days
Sponsored by:	The FreeBSD Foundation
Differential Revision: https://reviews.freebsd.org/D18374
Ticket:		#58653

(cherry picked from commit e420457ce04bb5435432d87f4d6c39d785955cf8)