### PR TITLE
Disable legacy CTL statistics.

### DIFF
--- a/sys/cam/ctl/ctl_ioctl.h
+++ b/sys/cam/ctl/ctl_ioctl.h
@@ -67,7 +67,7 @@
 #define	CTL_MINOR	225
 
 /* Legacy statistics accumulated for every port for every LU. */
-#define CTL_LEGACY_STATS	1
+//#define CTL_LEGACY_STATS	1
 
 typedef enum {
 	CTL_DELAY_TYPE_NONE,


### PR DESCRIPTION
It consumes significant memory, while appeared to be broken in 11.2
and not really needed, since I just rewritten collectd plugin.

Ticket:	#63402
(cherry picked from commit fee24d54e0cc54b05379c68fe4e97aafa0305abd)