### PR TITLE
MFC: r339289: Resolve a hang in ZFS during vnode reclaimation

### DIFF
--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_znode.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/zfs_znode.c
@@ -1155,14 +1155,26 @@ again:
 		 */
 		ASSERT3P(zp, !=, NULL);
 		ASSERT3U(zp->z_id, ==, obj_num);
-		*zpp = zp;
-		vp = ZTOV(zp);
-
-		/* Don't let the vnode disappear after ZFS_OBJ_HOLD_EXIT. */
-		VN_HOLD(vp);
+		if (zp->z_unlinked) {
+			err = SET_ERROR(ENOENT);
+		} else {
+			vp = ZTOV(zp);
+			/*
+			 * Don't let the vnode disappear after
+			 * ZFS_OBJ_HOLD_EXIT.
+			 */
+			VN_HOLD(vp);
+			*zpp = zp;
+			err = 0;
+		}
 
 		sa_buf_rele(db, NULL);
 		ZFS_OBJ_HOLD_EXIT(zfsvfs, obj_num);
+
+		if (err) {
+			getnewvnode_drop_reserve();
+			return (err);
+		}
 
 		locked = VOP_ISLOCKED(vp);
 		VI_LOCK(vp);
@@ -1196,7 +1208,7 @@ again:
 		}
 		VI_UNLOCK(vp);
 		getnewvnode_drop_reserve();
-		return (0);
+		return (err);
 	}
 
 	/*


### PR DESCRIPTION
  This is caused by a deadlock between zil_commit() and zfs_zget()
  Add a way for zfs_zget() to break out of the retry loop in the common case

PR:		229614, 231117
Reported by:	grembo, jhb, Andreas Sommer, others
Relnotes:	yes
Sponsored by:	Klara Systems

(cherry picked from commit bf6caa09b447187d08c959859e0ccde378ab6a1b)