### PR TITLE
Another fix for the mountd problem reported by Dave Flowers; (#158)

### DIFF
--- a/usr.sbin/mountd/mountd.c
+++ b/usr.sbin/mountd/mountd.c
@@ -1020,8 +1020,13 @@ mntsrv(struct svc_req *rqstp, SVCXPRT *transp)
 		syslog(LOG_ERR, "request from unknown address family");
 		return;
 	}
-	lookup_failed = getnameinfo(saddr, saddr->sa_len, host, sizeof host, 
-	    NULL, 0, 0);
+	switch (rqstp->rq_proc) {
+	case MOUNTPROC_MNT:
+	case MOUNTPROC_UMNT:
+	case MOUNTPROC_UMNTALL:
+		lookup_failed = getnameinfo(saddr, saddr->sa_len, host,
+		    sizeof host, NULL, 0, 0);
+	}
 	getnameinfo(saddr, saddr->sa_len, numerichost,
 	    sizeof numerichost, NULL, 0, NI_NUMERICHOST);
 	switch (rqstp->rq_proc) {


### PR DESCRIPTION
* Another fix for the mountd problem reported by Dave Flowers;
this one reduces the number of DNS calls made.

I'll be doing a differential revision for FreeBSD as soon as
my build for that finishes and I can test it.

Ticket: #55728

* Use 80 column lines; this again matches the freebsd differential
proposal.

Ticket: #55728
(cherry picked from commit 5aa097bc23aabb5b01252a77950d90765fe1a4f9)