### PR TITLE
Merge r340442 from FreeBSD.

### DIFF
--- a/usr.sbin/mountd/mountd.c
+++ b/usr.sbin/mountd/mountd.c
@@ -906,8 +906,12 @@ complete_service(struct netconfig *nconf, char *port_str)
 		if (fd < 0)
 			continue;
 
+		/*
+		 * Using -1 tells listen(2) to use
+		 * kern.ipc.soacceptqueue for the backlog.
+		 */
 		if (nconf->nc_semantics != NC_TPI_CLTS)
-			listen(fd, SOMAXCONN);
+			listen(fd, -1);
 
 		if (nconf->nc_semantics == NC_TPI_CLTS )
 			transp = svc_dg_create(fd, 0, 0);


### PR DESCRIPTION
mountd has no way to configure the listen queue depth; rather than add a new
option, we pass -1 down to listen, which causes it to use the
kern.ipc.soacceptqueue sysctl.

Ticket #55728

(cherry picked from commit bc6d51ea308e6a3172653684508c3f3975903d78)