### PR TITLE
Set GSS RPC to limited retry, and interruptible

### DIFF
--- a/sys/kgssapi/gss_acquire_cred.c
+++ b/sys/kgssapi/gss_acquire_cred.c
@@ -64,6 +64,15 @@ gss_acquire_cred(OM_uint32 *minor_status,
 	if (cl == NULL)
 		return (GSS_S_FAILURE);
 
+	/*
+	 * I apologise for this hack, but the number of retries
+	 * defaults to INT_MAX, which means an infinite, uninteruptable
+	 * hang in some cases.
+	 */
+	i = 1;
+	CLNT_CONTROL(cl, CLSET_RETRIES, &i);
+	CLNT_CONTROL(cl, CLSET_INTERRUPTIBLE, &i);
+
 	args.uid = curthread->td_ucred->cr_uid;
 	if (desired_name)
 		args.desired_name = desired_name->handle;


### PR DESCRIPTION
The gss RPC uses the default retry and interruptability values,
which end up being (respectively) INT_MAX and false.  Change
them to 1 and true.  This may not be in the final fix for this
issue, but it at least means not having to reboot.

Ticket: #43437