### PR TITLE
Redo the change to handle a hung nfsd:

### DIFF
--- a/sys/kgssapi/gss_acquire_cred.c
+++ b/sys/kgssapi/gss_acquire_cred.c
@@ -64,6 +64,14 @@ gss_acquire_cred(OM_uint32 *minor_status,
 	if (cl == NULL)
 		return (GSS_S_FAILURE);
 
+	/*
+	 * The number of retries defaults to INT_MAX, which means
+	 * an infinite, uninteruptible hang effectively.  We'll limit
+	 * it to five retries.
+	 */
+	i = 5;
+	CLNT_CONTROL(cl, CLSET_RETRIES, &i);
+
 	args.uid = curthread->td_ucred->cr_uid;
 	if (desired_name)
 		args.desired_name = desired_name->handle;

--- a/usr.sbin/gssd/gssd.c
+++ b/usr.sbin/gssd/gssd.c
@@ -202,6 +202,7 @@ main(int argc, char **argv)
 		signal(SIGHUP, SIG_IGN);
 	}
 	signal(SIGTERM, gssd_terminate);
+	signal(SIGPIPE, gssd_terminate);
 
 	memset(&sun, 0, sizeof sun);
 	sun.sun_family = AF_LOCAL;


### PR DESCRIPTION
* While the root cause hasn't yet been identified, gssd was getting
SIGPIPE when writing to the socket; since it didn't handle this, it
never cleaned up, resulting in the system continuing to try to talk
to it.

* Limit the number of retries for GSS to 5.

(This required intervention for the cherry pick.)

Ticket: #43437
(cherry picked from commit c4e508287a8cd3159a83e57c6aa744cb7f44eb86)