### PR TITLE
A small change (taken from ZoL) intended to mitigate the result of

### DIFF
--- a/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/abd.c
+++ b/sys/cddl/contrib/opensolaris/uts/common/fs/zfs/abd.c
@@ -290,7 +290,7 @@ abd_free_struct(abd_t *abd)
 abd_t *
 abd_alloc(size_t size, boolean_t is_metadata)
 {
-	if (!zfs_abd_scatter_enabled)
+	if (!zfs_abd_scatter_enabled || size <= PAGESIZE)
 		return (abd_alloc_linear(size, is_metadata));
 
 	VERIFY3U(size, <=, SPA_MAXBLOCKSIZE);


### PR DESCRIPTION
small alocations.  (The test case involved creating a zvol with
512-byte blocks.)

Ticket: #48273