### PR TITLE
Drop periph lock around cam_periph_unmapmem().

### DIFF
--- a/sys/cam/scsi/scsi_pass.c
+++ b/sys/cam/scsi/scsi_pass.c
@@ -2262,7 +2262,9 @@ passsendccb(struct cam_periph *periph, union ccb *ccb, union ccb *inccb)
 	    /* sense_flags */ SF_RETRY_UA | SF_NO_PRINT,
 	    softc->device_stats);
 
+	cam_periph_unlock(periph);
 	cam_periph_unmapmem(ccb, &mapinfo);
+	cam_periph_lock(periph);
 
 	ccb->ccb_h.cbfcnp = NULL;
 	ccb->ccb_h.periph_priv = inccb->ccb_h.periph_priv;

--- a/sys/cam/scsi/scsi_sg.c
+++ b/sys/cam/scsi/scsi_sg.c
@@ -916,7 +916,9 @@ sgsendccb(struct cam_periph *periph, union ccb *ccb)
 				  SF_RETRY_UA,
 				  softc->device_stats);
 
+	cam_periph_unlock(periph);
 	cam_periph_unmapmem(ccb, &mapinfo);
+	cam_periph_lock(periph);
 
 	return (error);
 }


### PR DESCRIPTION
Since r345656 it may call copyout(), that may sleep.

Ticket: #NAS-101635

(cherry picked from commit c8679b8bb2f1d0f7abae5972cca507cd14bf66ae)
(cherry picked from commit c66227642e48fc7aaa847bd88a12bcf5a9c1d49e)
(cherry picked from commit 79552630404d2b61dca02b1ee69b0a82ca5e187b)