### PR TITLE
daemon(8): Don't block SIGTERM during restart delay

### DIFF
--- a/usr.sbin/daemon/daemon.c
+++ b/usr.sbin/daemon/daemon.c
@@ -359,12 +359,13 @@ restart:
 			}
 		}
 	}
+	if (restart && !terminate)
+		daemon_sleep(restart, 0);
 	if (sigprocmask(SIG_BLOCK, &mask_term, NULL)) {
 		warn("sigprocmask");
 		goto exit;
 	}
 	if (restart && !terminate) {
-		daemon_sleep(restart, 0);
 		close(pfd[0]);
 		pfd[0] = -1;
 		goto restart;
@@ -384,7 +385,8 @@ static void
 daemon_sleep(time_t secs, long nsecs)
 {
 	struct timespec ts = { secs, nsecs };
-	while (nanosleep(&ts, &ts) == -1) {
+
+	while (!terminate && nanosleep(&ts, &ts) == -1) {
 		if (errno != EINTR)
 			err(1, "nanosleep");
 	}


### PR DESCRIPTION
I believe this was introduced in the original '-r' commit, r231911 (2012).
At the time, the scope was limited to a 1 second sleep.  r332518 (2018)
added '-R', which increased the potential duration of the affected interval
(from 1 to N seconds) by permitting arbitrary restart intervals.

Instead, handle SIGTERM normally during restart-sleep, when the monitored
process is not running, and shut down promptly.

(I noticed this behavior when debugging a child process that exited quickly
under the 'daemon -r -R 30' environment.  'kill <daemonpid>' had no
immediate effect and the monitor process slept until the next restart
attempt.  This was annoying.)

Reviewed by:	allanjude, imp, markj
Differential Revision:	https://reviews.freebsd.org/D20509

(cherry picked from commit 175ae3661abf2f4b0521067aaa5f2bbc1f9c8845)