### PR TITLE
Remove excessive devd dependencies

### DIFF
--- a/etc/rc.d/devd
+++ b/etc/rc.d/devd
@@ -4,7 +4,6 @@
 #
 
 # PROVIDE: devd
-# REQUIRE: netif ldconfig
 # BEFORE: NETWORKING mountcritremote
 # KEYWORD: nojail shutdown
 


### PR DESCRIPTION
We want to start devd before ix-syncdisks, but that gives us circular dependencies.
We don't need neither network, nor ldconfig for our devd use case.