### PR TITLE
add "-n" flag to sockstat to prevent numeric UID to user name translation

### DIFF
--- a/usr.bin/sockstat/sockstat.1
+++ b/usr.bin/sockstat/sockstat.1
@@ -68,6 +68,8 @@ or do not contain the IPv6 loopback address
 .Li ::1 .
 .It Fl l
 Show listening sockets.
+.It Fl n
+Do not try to resolve numeric UIDs to user names.
 .It Fl p Ar ports
 Only show Internet sockets if the local or foreign port number
 is on the specified list.

--- a/usr.bin/sockstat/sockstat.c
+++ b/usr.bin/sockstat/sockstat.c
@@ -78,6 +78,7 @@ static int	 opt_c;		/* Show connected sockets */
 static int	 opt_j;		/* Show specified jail */
 static int	 opt_L;		/* Don't show IPv4 or IPv6 loopback sockets */
 static int	 opt_l;		/* Show listening sockets */
+static int	 opt_n;		/* Don't try to resolve UIDs to user names */
 static int	 opt_q;		/* Don't show header */
 static int	 opt_S;		/* Show protocol stack if applicable */
 static int	 opt_s;		/* Show protocol state if applicable */
@@ -1187,7 +1188,7 @@ display(void)
 				continue;
 			s->shown = 1;
 			pos = 0;
-			if ((pwd = getpwuid(xf->xf_uid)) == NULL)
+			if (opt_n || (pwd = getpwuid(xf->xf_uid)) == NULL)
 				pos += xprintf("%lu ", (u_long)xf->xf_uid);
 			else
 				pos += xprintf("%s ", pwd->pw_name);
@@ -1286,7 +1287,7 @@ main(int argc, char *argv[])
 	int o, i;
 
 	opt_j = -1;
-	while ((o = getopt(argc, argv, "46cj:Llp:P:qSsUuvw")) != -1)
+	while ((o = getopt(argc, argv, "46cj:Llnp:P:qSsUuvw")) != -1)
 		switch (o) {
 		case '4':
 			opt_4 = 1;
@@ -1307,6 +1308,9 @@ main(int argc, char *argv[])
 			break;
 		case 'l':
 			opt_l = 1;
+			break;
+		case 'n':
+			opt_n = 1;
 			break;
 		case 'p':
 			parse_ports(optarg);


### PR DESCRIPTION
`sockstat` can "hang" on `getpwuid()` calls in situations when freeBSD is joined to a directory service (AD/LDAP etc) and the ability to query said directory service endpoints fail to answer in a timely manner when trying to resolve numeric UIDs to user names.