### PR TITLE
r368721: Drop EFI_STAGING_SIZE back down to 64M

### DIFF
--- a/stand/efi/loader/copy.c
+++ b/stand/efi/loader/copy.c
@@ -176,9 +176,7 @@ out:
 #endif /* __i386__ || __amd64__ */
 
 #ifndef EFI_STAGING_SIZE
-#if defined(__amd64__)
-#define	EFI_STAGING_SIZE	100
-#elif defined(__arm__)
+#if defined(__arm__)
 #define	EFI_STAGING_SIZE	32
 #else
 #define	EFI_STAGING_SIZE	64


### PR DESCRIPTION
EFI_STAGING_SIZE was originally raised to 100M for supporting large kernel modules like "nvidia.ko" but this will make VMware virtual machines unable to boot. This affects FreeBSD 12.2 and TrueNAS 12, including the latest 12.0-U2.1 release.
While pfSense [reverted](https://github.com/pfsense/FreeBSD-src/commit/ecba14136e2b35c8eed722409563abbfd55f80a5) it to 64M after FreeBSD upstream drops it back in revision [368721](https://svnweb.freebsd.org/base?view=revision&revision=368721), which makes their 2.5 release works with no issues, I believe there are users running TrueNAS in ESXi VMs, and it's nice for us to drop it back.

Original commit message from @bsdimp

vmware can't cope with anything larger than 64MB. Drop this back to
64MB everywhere but arm.

PR: 251866
MFC After: 1 week
