### PR TITLE
Reduce yp retries

### DIFF
--- a/lib/libc/yp/yplib.c
+++ b/lib/libc/yp/yplib.c
@@ -90,7 +90,7 @@ struct dom_binding {
 #ifndef BINDINGDIR
 #define BINDINGDIR "/var/yp/binding"
 #endif
-#define MAX_RETRIES 20
+#define MAX_RETRIES 5
 
 extern bool_t xdr_domainname(), xdr_ypbind_resp();
 extern bool_t xdr_ypreq_key(), xdr_ypresp_val();


### PR DESCRIPTION
Library defaults to 20 retries with 10 second sleeps in between them. This is rather excessive for our purposes. When NIS is misconfigured, this will result in nss queries hanging for 200 seconds. Drop the retry count to 5. The probability of succeeding after five failures is vanishingly small and itself an error condition in the domain that should most likely be addressed.