### PR TITLE
NAS-113513 / Add special utimensat(2) flag to allow setting explicit birthtime

### DIFF
--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -229,6 +229,7 @@ typedef	__pid_t		pid_t;
 #endif	/* __POSIX_VISIBLE >= 200809 */
 #if __BSD_VISIBLE
 /* #define AT_UNUSED1		0x1000 *//* Was AT_BENEATH */
+#define	AT_UTIMENSAT_BTIME	0x1000
 #define	AT_RESOLVE_BENEATH	0x2000	/* Do not allow name resolution
 					   to walk out of dirfd */
 #define	AT_EMPTY_PATH		0x4000	/* Operate on dirfd if path is empty */


### PR DESCRIPTION
Some applications over SMB protocol may inadvertently initialize
the inode birthtime to 1980 due to non-standard FreeBSD setutimes()
behavior, which applies the mtime timespec to birthtime if it is
older than existing birthtime. It is not possible to fix this using
existing calls to utimensat(2) or futimens(2). Additionally,
SMB clients, may attempt to set birthtime to a date more recent
than the mtime.

This PR adds a utimensat(2) flag that may be used to
specify that  an array of three timespecs are being provided rather
than two. In this case the third timespec struct specifies the
birthtime to be set.