### PR TITLE
NAS-114370 / Add sysctl to allow unprivileged processes to get generation

### DIFF
--- a/sys/kern/kern_priv.c
+++ b/sys/kern/kern_priv.c
@@ -94,6 +94,11 @@ SYSCTL_INT(_security_bsd, OID_AUTO, unprivileged_read_msgbuf,
     CTLFLAG_RW, &unprivileged_read_msgbuf, 0,
     "Unprivileged processes may read the kernel message buffer");
 
+static int	unprivileged_inode_gen;
+SYSCTL_INT(_security_bsd, OID_AUTO, unprivileged_inode_gen,
+    CTLFLAG_RWTUN, &unprivileged_inode_gen, 0,
+    "Unprivileged processes may read inode generation");
+
 SDT_PROVIDER_DEFINE(priv);
 SDT_PROBE_DEFINE1(priv, kernel, priv_check, priv__ok, "int");
 SDT_PROBE_DEFINE1(priv, kernel, priv_check, priv__err, "int");
@@ -340,7 +345,8 @@ priv_check_cred_vfs_generation_slow(struct ucred *cred)
 		goto out;
 	}
 
-	if (cred->cr_uid == 0 && suser_enabled(cred)) {
+	if (unprivileged_inode_gen ||
+	    (cred->cr_uid == 0 && suser_enabled(cred))) {
 		error = 0;
 		goto out;
 	}
@@ -361,7 +367,8 @@ priv_check_cred_vfs_generation(struct ucred *cred)
 		return (priv_check_cred_vfs_generation_slow(cred));
 
 	error = EPERM;
-	if (!jailed(cred) && cred->cr_uid == 0 && suser_enabled(cred))
+	if (!jailed(cred) && (unprivileged_inode_gen ||
+            (cred->cr_uid == 0 && suser_enabled(cred))))
 		error = 0;
 	return (error);
 }


### PR DESCRIPTION
Add sysctl option to allow unprivileged to obtain inode
generation information. This matches linux behavior
where non-root user can issue ioctl to get this info or
call name_to_handle_at(2) to construct an NFS handle.

The proposed use of this sysctl is for case where server
has SMB shares and needs to provide SMB clients with a
unique 64-bit file id per MS-SMB2 2.2.14.2.9 / MS-FSCC 2.1.9.
In this case, we will generate the file id from the inode
and generation.