### PR TITLE
Alter privilege check for getfhat

### DIFF
--- a/sys/kern/kern_priv.c
+++ b/sys/kern/kern_priv.c
@@ -372,3 +372,12 @@ priv_check_cred_vfs_generation(struct ucred *cred)
 		error = 0;
 	return (error);
 }
+
+int
+priv_check_cred_vfs_getfhat(struct ucred *cred)
+{
+	if (!jailed(cred) && unprivileged_inode_gen)
+		return (0);
+
+	return priv_check_cred(cred, PRIV_VFS_GETFH);
+}

--- a/sys/sys/priv.h
+++ b/sys/sys/priv.h
@@ -540,6 +540,7 @@ int	priv_check_cred(struct ucred *cred, int priv);
 int	priv_check_cred_vfs_lookup(struct ucred *cred);
 int	priv_check_cred_vfs_lookup_nomac(struct ucred *cred);
 int	priv_check_cred_vfs_generation(struct ucred *cred);
+int	priv_check_cred_vfs_getfhat(struct ucred *cred);
 #endif
 
 #endif /* !_SYS_PRIV_H_ */


### PR DESCRIPTION
* allow converting fd into fhandle_t via AT_EMPTY_PATH
* allow sysctl allowing unprivileged inode generation access to also
  allow getfhat.
  
These changes allow smbd process to convert an open fd into opaque file
handle that is in process of being plumbed into our our Samba server to
use as fast-path for looking up / opening files (helps in workloads
that are constantly opening / closing files).