### PR TITLE
NAS-121694 / None / Give more useful error message for ypwhich failure

### DIFF
--- a/usr.bin/ypwhich/ypwhich.c
+++ b/usr.bin/ypwhich/ypwhich.c
@@ -99,6 +99,7 @@ bind_host(char *dom, struct sockaddr_in *sin)
 	client = clntudp_create(sin, YPBINDPROG, YPBINDVERS, tv, &sock);
 
 	if (client == NULL) {
+		clnt_pcreateerror("ypwhich_bind_host");
 		warnx("host is not bound to a ypmaster");
 		return (YPERR_YPBIND);
 	}


### PR DESCRIPTION
We should print out the RPC error message rather than only stating that the host is not boudn to a ypmaster. This will help support diagnose the actual underlying issue.