### PR TITLE
Alter privilege check for getfhat

### DIFF
--- a/sys/kern/kern_priv.c
+++ b/sys/kern/kern_priv.c
@@ -372,3 +372,12 @@ priv_check_cred_vfs_generation(struct ucred *cred)
 		error = 0;
 	return (error);
 }
+
+int
+priv_check_cred_vfs_getfhat(struct ucred *cred)
+{
+	if (!jailed(cred) && unprivileged_inode_gen)
+		return (0);
+
+	return priv_check_cred(cred, PRIV_VFS_GETFH);
+}

--- a/sys/kern/vfs_syscalls.c
+++ b/sys/kern/vfs_syscalls.c
@@ -4425,14 +4425,18 @@ kern_getfhat(struct thread *td, int flags, int fd, const char *path,
 	struct vnode *vp;
 	int error;
 
-	if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH)) != 0)
+	if ((flags &
+	     ~(AT_SYMLINK_NOFOLLOW | AT_RESOLVE_BENEATH | AT_EMPTY_PATH)) != 0)
 		return (EINVAL);
-	error = priv_check(td, PRIV_VFS_GETFH);
-	if (error != 0)
+
+	error = priv_check_cred_vfs_getfhat(td->td_ucred);
+	if (error != 0) {
 		return (error);
+	}
+
 	NDINIT_AT(&nd, LOOKUP, at2cnpflags(flags, AT_SYMLINK_NOFOLLOW |
-	    AT_RESOLVE_BENEATH) | LOCKLEAF | AUDITVNODE1, pathseg, path,
-	    fd, td);
+	    AT_RESOLVE_BENEATH | AT_EMPTY_PATH) | LOCKLEAF | AUDITVNODE1,
+	    pathseg, path, fd, td);
 	error = namei(&nd);
 	if (error != 0)
 		return (error);

--- a/sys/sys/priv.h
+++ b/sys/sys/priv.h
@@ -542,6 +542,7 @@ int	priv_check_cred(struct ucred *cred, int priv);
 int	priv_check_cred_vfs_lookup(struct ucred *cred);
 int	priv_check_cred_vfs_lookup_nomac(struct ucred *cred);
 int	priv_check_cred_vfs_generation(struct ucred *cred);
+int	priv_check_cred_vfs_getfhat(struct ucred *cred);
 #endif
 
 #endif /* !_SYS_PRIV_H_ */


### PR DESCRIPTION
* allow converting fd into fhandle_t via AT_EMPTY_PATH
* allow sysctl allowing unprivileged inode generation access to also allow getfhat.

These changes allow smbd process to convert an open fd into opaque file handle that is in process of being plumbed into our our Samba server to use as fast-path for looking up / opening files (helps in workloads that are constantly opening / closing files).