### PR TITLE
NAS-133472 / 13.3 / isp: Fix abort issue introduced by previous commit

### DIFF
--- a/sys/dev/isp/isp_freebsd.h
+++ b/sys/dev/isp/isp_freebsd.h
@@ -104,8 +104,9 @@ typedef struct atio_private_data {
 	uint16_t	ctcnt;	/* number of CTIOs currently active */
 	uint8_t		seqno;	/* CTIO sequence number */
 	uint8_t		cdb0;
-	uint8_t		srr_notify_rcvd	: 1,
+	uint16_t	srr_notify_rcvd	: 1,
 			sendst		: 1,
+			dead		: 1,
 			tattr		: 3,
 			state		: 3;
 	void *		ests;


### PR DESCRIPTION
Aborting ATIO while its CTIOs are in progress makes impossible to handle their completions, making them stuck forever.  Detect this case by checking ctcnt counter and if so instead of aborting just mark the ATIO as dead to block any new CTIOs.  It is not perfect since the task id can not be reused for some more time, but not as bad as the task stuck forever.