### PR TITLE
NAS-133472 / None / isp: Fix abort issue introduced by previous commit

### DIFF
--- a/sys/dev/isp/isp_freebsd.c
+++ b/sys/dev/isp/isp_freebsd.c
@@ -980,6 +980,16 @@ isp_target_start_ctio(ispsoftc_t *isp, union ccb *ccb, enum Start_Ctio_How how)
 		}
 
 		/*
+		 * Is this command a dead duck?
+		 */
+		if (atp->dead) {
+			isp_prt(isp, ISP_LOGERR, "%s: [0x%x] not sending a CTIO for a dead command", __func__, cso->tag_id);
+			ccb->ccb_h.status = CAM_REQ_ABORTED;
+			xpt_done(ccb);
+			continue;
+		}
+
+		/*
 		 * Check to make sure we're still in target mode.
 		 */
 		fcp = FCPARAM(isp, XS_CHANNEL(ccb));
@@ -2496,14 +2506,19 @@ isp_action(struct cam_sim *sim, union ccb *ccb)
 		}
 
 		/*
-		 * Target should abort all affected CCBs before ACK-ing INOT,
+		 * Target should abort all affected tasks before ACK-ing INOT,
 		 * but if/since it doesn't, add this hack to allow tag reuse.
+		 * We can not do it if some CTIOs are in progress, or we won't
+		 * handle the completions.  In such case just block new ones.
 		 */
 		uint32_t rsp = (ccb->ccb_h.flags & CAM_SEND_STATUS) ? ccb->cna2.arg : 0;
 		if (ntp->nt.nt_ncode == NT_ABORT_TASK && (rsp & 0xff) == 0 &&
 		    (atp = isp_find_atpd(isp, XS_CHANNEL(ccb), ccb->cna2.seq_id)) != NULL) {
-			if (isp_abort_atpd(isp, XS_CHANNEL(ccb), atp) == 0)
+			if (atp->ctcnt == 0 &&
+			    isp_abort_atpd(isp, XS_CHANNEL(ccb), atp) == 0)
 				isp_put_atpd(isp, XS_CHANNEL(ccb), atp);
+			else
+				atp->dead = 1;
 		}
 
 		if (isp_handle_platform_target_notify_ack(isp, &ntp->nt, rsp)) {

--- a/sys/dev/isp/isp_freebsd.h
+++ b/sys/dev/isp/isp_freebsd.h
@@ -105,8 +105,9 @@ typedef struct atio_private_data {
 	uint16_t	ctcnt;	/* number of CTIOs currently active */
 	uint8_t		seqno;	/* CTIO sequence number */
 	uint8_t		cdb0;
-	uint8_t		srr_notify_rcvd	: 1,
+	uint16_t	srr_notify_rcvd	: 1,
 			sendst		: 1,
+			dead		: 1,
 			tattr		: 3,
 			state		: 3;
 	void *		ests;


### PR DESCRIPTION
Aborting ATIO while its CTIOs are in progress makes impossible to handle their completions, making them stuck forever.  Detect this case by checking ctcnt counter and if so instead of aborting just mark the ATIO as dead to block any new CTIOs.  It is not perfect since the task id can not be reused for some more time, but not as bad as the task stuck forever.